### PR TITLE
Fix missing department

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -103,7 +103,7 @@ Layout/AlignHash:
   EnforcedColonStyle: table
 Style/FrozenStringLiteralComment:
   Enabled: false
-SingleLineMethods:
+Style/SingleLineMethods:
   Enabled: false
 Style/Lambda:
   EnforcedStyle: literal


### PR DESCRIPTION
As of Rubocop 0.75 it raises a warning when department is missing